### PR TITLE
Initial governance suggestion

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,9 @@ with `admin` access to repositories within the organization.
 
 The Core Team are the only members of the `@eslint-community/core-team` team.
 
+The Core Team and ESLint TSC have a shared `#community-team` chat room, in the ESLint
+Discord, to communicate with one another.
+
 ## ESLint TSC
 
 The ESLint TSC are the ultimate caretakers of the ESLint-Community, appoints the Core
@@ -25,6 +28,9 @@ The Core Team are together with the ESLint TSC the organization owners and only 
 with `admin` access to repositories within the organization.
 
 The ESLint TSC are the only members of the `@eslint-community/eslint-tsc` team.
+
+The Core Team and ESLint TSC have a shared `#community-team` chat room, in the ESLint
+Discord, to communicate with one another.
 
 ## Collaborators
 
@@ -42,6 +48,8 @@ Both Collaborators and non-Collaborators may propose changes to the source code
 of the projects of the organization. The mechanism to propose such a change is a
 GitHub pull request. Collaborators review and merge (_land_) pull requests
 following the [CONTRIBUTING](CONTRIBUTING.md) guidelines.
+
+Collaborators can communicate in private with the Core Team [on GitHub](https://github.com/eslint-community/collaborators/discussions).
 
 ### Collaborator activities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,179 @@
+# ESLint-Community Governance
+
+## Core Team
+
+The Core Team are the curators and stewards of the ESLint-Community project . Their key
+responsibility is to evaluate new projects that are proposed to join `@eslint-community`
+and to help out in offering a base level maintenance for all primary projects within
+the organization.
+
+The Core Team should have occasional meetings to discuss the project, with meeting minutes
+being added to [eslint-community/governance](https://github.com/eslint-community/governance).
+
+The Core Team are together with the ESLint TSC the organization owners and the only ones
+with `admin` access to repositories within the organization.
+
+The Core Team are the only members of the `@eslint-community/core-team` team.
+
+## ESLint TSC
+
+The ESLint TSC are the ultimate caretakers of the ESLint-Community, appoints the Core
+Team and holds the ownership of the `eslint-community-bot` npm account that owns all
+the ESLint-Community npm modules.
+
+The Core Team are together with the ESLint TSC the organization owners and only ones
+with `admin` access to repositories within the organization.
+
+The ESLint TSC are the only members of the `@eslint-community/eslint-tsc` team.
+
+## Collaborators
+
+Collaborators maintain the projects of the ESLint-Community organization.
+
+Collaborators are added on a project by project basis by adding them to a team of
+the same name as its main project repository, eg. `@eslint-community/eslint-plugin`.
+
+A project team is given `write` level access to its repositories.
+
+If multiple repositores are needed by the same project they should all be added to
+the project team.
+
+Both Collaborators and non-Collaborators may propose changes to the source code
+of the projects of the organization. The mechanism to propose such a change is a
+GitHub pull request. Collaborators review and merge (_land_) pull requests
+following the [CONTRIBUTING](CONTRIBUTING.md) guidelines.
+
+### Collaborator activities
+
+* Helping users and novice contributors
+* Contributing code and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Merging pull requests
+* Release plugins
+
+The Core Team can remove inactive Collaborators or provide them with
+_Past Collaborators_ status. Past Collaborators may request that the Core
+Team restore them to active status.
+
+## Projects
+
+There are two kinds of projects in ESLint Community: Primary and auxiliary projects.
+
+Primary projects are maintained by Core Team in collaboration with project Collaborators
+and will be ensured to be kept up to date at a best effort pace by the Core Team.
+
+Auxiliary projects are maintained by its project Collaborators and is kept up to date at
+whatever pace those Collaborators chose. The Core Team merely fascilitates nominations
+of new Collaborators to such projects, ensuring there's a path to keep it maintained,
+without making any promises.
+
+All project npm modules should be owned (and solely owned) by the `eslint-community-bot`
+user on npm and automatic releases should be set up by the Core Team using the organization
+secret in the GitHub organization.
+
+Additional assets such as domain names, web sites etc should also be in control of the
+Core Team and/or the ESLint TSC.
+
+Auxiliary projects can can be nominated to become a primary project by its Collaborators,
+by opening a private team discussion [on GitHub](https://github.com/eslint-community/collaborators/discussions).
+
+If a primary project is no longer widely depended upon, or have technical reasons to no
+longer stay a primary project, the Core Team can decide to convert it into an auxiliary
+project in discussion with its Collaborators.
+
+## Project nominations
+
+Projects that are widely depended upon within the ESLint ecosystem may be nominated to
+become ESLint-Community projects by anyone by opening a public issue [on GitHub](https://github.com/eslint-community/governance).
+The project should fulfill a few criterias:
+
+The project should:
+
+* Preferably be: An ESLint plugin or formatter
+* Maybe be: A dependency used by an ESLint-Community project or the main ESLint repo
+* Not be: Primarily an ESLint config
+
+The project should also:
+
+* be widely depended upon throughout the community (eg. 3M downloads/week or similar)
+* have an OSI-approved license (preferably same as ESLint itself: MIT)
+* have proposed Collaborators or have possibility to be deemed a Primary project
+  by the Core Team
+
+If project currentlu has an active maintainer it should be transfered and then:
+
+* the current maintainer should be willing to transfer the project to ESLint-Community
+
+If its an abandoned project that needs to be forked:
+
+* It shouldn't have received an update in a substantial amount of time (eg. last 6 months)
+  or it should present a major obstacle to the adoption of eg. a new major version of ESLint
+* A clear notice about the nomination should have been made to the project and its
+  maintainer at least 30 days before it can be accepted
+
+Projects should typically start out with a status of "auxiliary".
+
+## Collaborator nominations
+
+Individuals making significant and valuable contributions to a project may be
+a candidate to join the ESLint-Community organization and that team.
+
+An existing Collaborator needs to open a private team discussion [on GitHub](https://github.com/eslint-community/collaborators/discussions) and
+list the candidates they want to sponsor with a link to the user's contributions. For
+example:
+
+* Activities in the ESLint-Community organization
+  `[USERNAME](https://github.com/search?q=author:USERNAME+org:eslint-community)`
+
+Otherwise, a Contributor may self-apply if they believe they meet the above
+criteria by reaching out to a Core Team member privately with the links to their
+valuable contributions. That Lead Maintainer will then open a private team discussion on
+GitHub regarding that and reply back when a decision has been made.
+
+The consensus to grant a new candidate Collaborator status is reached when:
+
+- at least two of the Core Team members approve
+- at least half of the current collaborators in that team approve, rounded up
+  (and not counting Core Team members)
+
+## Core Team nominations
+
+A Team Member may be promoted to the Core Team only through nomination by a
+Core Team member and with agreement from the rest of Core Team as well as the
+ESLint TSC.
+
+The ESLint TSC can appoint and revoke Core Team members at their own discretion.
+
+## Consensus seeking process
+
+The ESLint Community follows a Lazy [Consensus Seeking]() decision-making model,
+inspired by the [ASF]().
+
+_Lazy_ means that silence is consent if an appropriate amount of time has passed
+(most of the time: at least a week) since the suggestion was made and no objections
+has been raised.
+
+This only holds true if all relevant parties has been notified of the suggestion
+and given the opportunity to take part. Eg. extra care needs to be taken during
+holiday and vacation times.
+
+Decision makers should strive to give active consent and not actively wait out
+silent consent.
+
+### Votes
+
+In case of a Collaborator objection to a specific change, the Core Team can
+vote to override the objection if consensus can not be reached.
+
+For all votes, a simple majority of all Core Team members for, or against, the
+issue wins. A Core Team member may choose to participate in any vote through
+abstention.
+
+The ESLint TSC can decide to override / veto any decision / objection made by
+Collaborators or Core Team. The ESLint Project decides how to arrive at
+such decisions.
+
+[Consensus Seeking]:
+    https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[ASF]:
+    https://community.apache.org/committers/decisionMaking.html

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -68,11 +68,18 @@ of new Collaborators to such projects, ensuring there's a path to keep it mainta
 without making any promises.
 
 All project npm modules should be owned (and solely owned) by the `eslint-community-bot`
-user on npm and automatic releases should be set up by the Core Team using the organization
-secret in the GitHub organization.
+user on npm. If the npm modules are owned by an existing organisation and using its prefix,
+then the `eslint-community-bot` should become the sole owner of that organisation.
 
 Additional assets such as domain names, web sites etc should also be in control of the
 Core Team and/or the ESLint TSC.
+
+If possible, a project should always be transfered and keep using its original npm module
+name and repository. If a new module name needs to be created, it should preferably be
+`@eslint-community/<the-old-name>`.
+
+Automatic releases of the modules should be set up by the Core Team using the organization
+secret in the GitHub organization.
 
 Auxiliary projects can can be nominated to become a primary project by its Collaborators,
 by opening a private team discussion [on GitHub](https://github.com/eslint-community/collaborators/discussions).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -114,7 +114,7 @@ The project should:
 The project should also:
 
 * be widely depended upon throughout the community (eg. 3M downloads/week or similar)
-* have an OSI-approved license (preferably same as ESLint itself: MIT)
+* have an OSI-approved license (preferably Apache 2.0, else MIT-style)
 * have proposed Collaborators or have possibility to be deemed a Primary project
   by the Core Team
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ and to help out in offering a base level maintenance for all primary projects wi
 the organization.
 
 The Core Team should have occasional meetings to discuss the project, with meeting minutes
-being added to [eslint-community/governance](https://github.com/eslint-community/governance).
+being added to [eslint-community/governance][].
 
 The Core Team are together with the ESLint TSC the organization owners and the only ones
 with `admin` access to repositories within the organization.
@@ -49,7 +49,8 @@ of the projects of the organization. The mechanism to propose such a change is a
 GitHub pull request. Collaborators review and merge (_land_) pull requests
 following the [CONTRIBUTING](CONTRIBUTING.md) guidelines.
 
-Collaborators can communicate in private with the Core Team [on GitHub](https://github.com/eslint-community/collaborators/discussions).
+Collaborators can communicate in private with the Core Team in
+[private team discussion on GitHub][].
 
 ### Collaborator activities
 
@@ -90,7 +91,7 @@ Automatic releases of the modules should be set up by the Core Team using the or
 secret in the GitHub organization.
 
 Auxiliary projects can can be nominated to become a primary project by its Collaborators,
-by opening a private team discussion [on GitHub](https://github.com/eslint-community/collaborators/discussions).
+by opening a [private team discussion on GitHub][].
 
 If a primary project is no longer widely depended upon, or have technical reasons to no
 longer stay a primary project, the Core Team can decide to convert it into an auxiliary
@@ -99,7 +100,9 @@ project in discussion with its Collaborators.
 ## Project nominations
 
 Projects that are widely depended upon within the ESLint ecosystem may be nominated to
-become ESLint-Community projects by anyone by opening a public issue [on GitHub](https://github.com/eslint-community/governance).
+become ESLint-Community projects by anyone by opening a public issue on GitHub in the
+[eslint-community/governance][] repository.
+
 The project should fulfill a few criterias:
 
 The project should:
@@ -133,7 +136,7 @@ Projects should typically start out with a status of "auxiliary".
 Individuals making significant and valuable contributions to a project may be
 a candidate to join the ESLint-Community organization and that team.
 
-An existing Collaborator needs to open a private team discussion [on GitHub](https://github.com/eslint-community/collaborators/discussions) and
+An existing Collaborator needs to open a [private team discussion on GitHub][] and
 list the candidates they want to sponsor with a link to the user's contributions. For
 example:
 
@@ -161,8 +164,8 @@ The ESLint TSC can appoint and revoke Core Team members at their own discretion.
 
 ## Consensus seeking process
 
-The ESLint Community follows a Lazy [Consensus Seeking]() decision-making model,
-inspired by the [ASF]().
+The ESLint Community follows a Lazy [Consensus Seeking][] decision-making model,
+inspired by the [ASF][].
 
 _Lazy_ means that silence is consent if an appropriate amount of time has passed
 (most of the time: at least a week) since the suggestion was made and no objections
@@ -192,3 +195,7 @@ such decisions.
     https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [ASF]:
     https://community.apache.org/committers/decisionMaking.html
+[eslint-community/governance]:
+    https://github.com/eslint-community/governance
+[private team discussion on GitHub]:
+    https://github.com/eslint-community/collaborators/discussions

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -115,11 +115,11 @@ The project should also:
 * have proposed Collaborators or have possibility to be deemed a Primary project
   by the Core Team
 
-If project currentlu has an active maintainer it should be transfered and then:
+If project currently has an active maintainer it should be transfered and then:
 
 * the current maintainer should be willing to transfer the project to ESLint-Community
 
-If its an abandoned project that needs to be forked:
+If it's an abandoned project that needs to be forked:
 
 * It shouldn't have received an update in a substantial amount of time (eg. last 6 months)
   or it should present a major obstacle to the adoption of eg. a new major version of ESLint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eslint-Community Governance
+# ESLint-Community Governance
 
 ## Purpose
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ See [GOVERNANCE.md](./GOVERNANCE.md)
 * [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise) (Collaborators: [@xjamundx](https://github.com/xjamundx), [@bmish](https://github.com/bmish))
 * [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) (Collaborators: [@nzakas](https://github.com/nzakas), [@nlf](https://github.com/nlf))
 * [eslint-utils](https://github.com/eslint-community/eslint-utils) (Collaborators: )
-* [eslint-formatter-codeframe](https://github.com/eslint-community/) (Collaborators: )
-* [eslint-formatter-table](https://github.com/eslint-community/) (Collaborators: )
-* [eslint-plugin-mysticatea](https://github.com/eslint-community/) (Collaborators: )
-* [regexpp](https://github.com/eslint-community/) (Collaborators: )
+* [eslint-formatter-codeframe](https://github.com/eslint-community/eslint-formatter-codeframe) (Collaborators: )
+* [eslint-formatter-table](https://github.com/eslint-community/eslint-formatter-table) (Collaborators: )
+* [eslint-plugin-mysticatea](https://github.com/eslint-community/eslint-plugin-mysticatea) (Collaborators: )
+* [regexpp](https://github.com/eslint-community/regexpp) (Collaborators: )
 
 ### Auxiliary projects
 
-* [eslint-stylistic](https://github.com/eslint-community/)  (Collaborators: [@Shinigami92](https://github.com/Shinigami92), [@antfu](https://github.com/antfu), [@kecrily](https://github.com/kecrily))
-  * [eslint-stylistic-repro-template](https://github.com/eslint-community/)
+* [eslint-stylistic](https://github.com/eslint-community/eslint-stylistic)  (Collaborators: [@Shinigami92](https://github.com/Shinigami92), [@antfu](https://github.com/antfu), [@kecrily](https://github.com/kecrily))
+  * [eslint-stylistic-repro-template](https://github.com/eslint-community/eslint-stylistic-repro-template)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# Governance
+# Eslint-Community Governance
 
-Outlines the governance of [@eslint-community](https://github.com/eslint-community) and fascilitates proposals and nominations
+## Purpose
 
-## Goal
+To have a place where community members can help ensure that widely depended upon ESLint-related packages live and never fall out of maintenance.
 
-As you can read in the
-["`eslint-community` GitHub organization" RFC](https://github.com/eslint/rfcs/tree/main/designs/2022-community-eslint-org),
-the goal of this organization is to have a place where community members can
-help ensure widely depended upon ESLint-related packages live and never fall out
-of maintenance.
+## Governance
+
+See [GOVERNANCE.md](./GOVERNANCE.md)
 
 ## The Community Core team
 
@@ -16,3 +14,25 @@ of maintenance.
 * [`@MichaelDeBoey`](https://github.com/MichaelDeBoey)
 * [`@ota-meshi`](https://github.com/ota-meshi)
 * [`@voxpelli`](https://github.com/voxpelli)
+
+
+## Projects
+
+### Primary projects
+
+* [eslint-plugin-es-x](https://github.com/eslint-community/eslint-plugin-es-x) (Collaborators: [@brettz9](https://github.com/brettz9))
+* [eslint-plugin-eslint-comments](https://github.com/eslint-community/eslint-plugin-eslint-comments) (Collaborators: )
+* [eslint-plugin-eslint-plugin](https://github.com/eslint-community/eslint-plugin-eslint-plugin) (Collaborators: [@bmish](https://github.com/bmish), [@bradzacher](https://github.com/bradzacher))
+* [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n) (Collaborators: [@scagood](https://github.com/scagood))
+* [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise) (Collaborators: [@xjamundx](https://github.com/xjamundx), [@bmish](https://github.com/bmish))
+* [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security) (Collaborators: [@nzakas](https://github.com/nzakas), [@nlf](https://github.com/nlf))
+* [eslint-utils](https://github.com/eslint-community/eslint-utils) (Collaborators: )
+* [eslint-formatter-codeframe](https://github.com/eslint-community/) (Collaborators: )
+* [eslint-formatter-table](https://github.com/eslint-community/) (Collaborators: )
+* [eslint-plugin-mysticatea](https://github.com/eslint-community/) (Collaborators: )
+* [regexpp](https://github.com/eslint-community/) (Collaborators: )
+
+### Auxiliary projects
+
+* [eslint-stylistic](https://github.com/eslint-community/)  (Collaborators: [@Shinigami92](https://github.com/Shinigami92), [@antfu](https://github.com/antfu), [@kecrily](https://github.com/kecrily))
+  * [eslint-stylistic-repro-template](https://github.com/eslint-community/)


### PR DESCRIPTION
As discussed by some of us on chat, its good if we formalize the governance of this project.

Here's a proposal that's written with inspiration from [the RFC](https://github.com/eslint/rfcs/tree/main/designs/2022-community-eslint-org), [other community governance docs ](https://github.com/fastify/.github/blob/main/GOVERNANCE.md) and my own head – trying to be constructive yet not step on anyone's toes.

I would propose setting up an issue template for nominating new projects if this PR is accepted, that would make it easier to gather all relevant pieces, and I can volunteer to do so.

I also took the liberty of setting up https://github.com/eslint-community/collaborators/discussions where all collaborators as well as the ESLint TSC and us in the Core Team can discuss nominations etc in private (which is the respectful thing to do when eg. a person is nominated, one shouldn't evaluate them in the open)